### PR TITLE
Add missing attached assets helpers for Bitcoin analysis

### DIFF
--- a/attached_assets/__init__.py
+++ b/attached_assets/__init__.py
@@ -1,0 +1,14 @@
+"""Helper utilities and data for the WebScrapeHelper app."""
+
+__all__ = [
+    "calculate_message_hash",
+    "format_hex",
+    "int_to_bytes",
+    "bytes_to_int",
+    "validate_transaction_id",
+    "ADDRESSES_TO_CHECK",
+]
+
+from .utils import calculate_message_hash, format_hex, int_to_bytes, bytes_to_int
+from .validators import validate_transaction_id
+from .address_list import ADDRESSES_TO_CHECK

--- a/attached_assets/address_list.py
+++ b/attached_assets/address_list.py
@@ -1,0 +1,8 @@
+"""Predefined Bitcoin addresses for quick scanning routes."""
+
+# A small curated list of mainnet addresses to bootstrap address-based scans.
+ADDRESSES_TO_CHECK = [
+    "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa",  # Genesis address
+    "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy",
+    "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080",
+]

--- a/attached_assets/utils.py
+++ b/attached_assets/utils.py
@@ -1,0 +1,37 @@
+"""Utility helpers used by the Bitcoin analysis tools."""
+
+import hashlib
+from typing import Union
+
+
+def format_hex(value: Union[int, bytes, str]) -> str:
+    """Return a hex string with ``0x`` prefix and even length."""
+    if isinstance(value, bytes):
+        hex_value = value.hex()
+    elif isinstance(value, int):
+        hex_value = hex(value)[2:]
+    else:
+        hex_value = str(value)
+        if hex_value.startswith("0x"):
+            hex_value = hex_value[2:]
+    if len(hex_value) % 2:
+        hex_value = f"0{hex_value}"
+    return f"0x{hex_value.lower()}"
+
+
+def calculate_message_hash(message_hex: str) -> bytes:
+    """Calculate the double-SHA256 hash of a hex-encoded message."""
+    if message_hex.startswith("0x"):
+        message_hex = message_hex[2:]
+    message_bytes = bytes.fromhex(message_hex)
+    return hashlib.sha256(hashlib.sha256(message_bytes).digest()).digest()
+
+
+def int_to_bytes(value: int, length: int = 32) -> bytes:
+    """Convert an integer to big-endian bytes, padded to ``length``."""
+    return value.to_bytes(length, byteorder="big")
+
+
+def bytes_to_int(value: bytes) -> int:
+    """Convert a byte sequence to an integer."""
+    return int.from_bytes(value, byteorder="big")

--- a/attached_assets/validators.py
+++ b/attached_assets/validators.py
@@ -1,0 +1,12 @@
+"""Validation helpers for API inputs."""
+
+import re
+
+_TX_ID_PATTERN = re.compile(r"^[0-9a-fA-F]{64}$")
+
+
+def validate_transaction_id(tx_id: str) -> bool:
+    """Return ``True`` when ``tx_id`` is a 64-character hex string."""
+    if not isinstance(tx_id, str):
+        return False
+    return bool(_TX_ID_PATTERN.fullmatch(tx_id.strip()))


### PR DESCRIPTION
## Summary
- add the attached_assets package with hashing and formatting utilities used by the Bitcoin analysis endpoints
- include validation helpers and a starter list of addresses to support API routes

## Testing
- python -m compileall attached_assets btc_analyzer.py app.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693117ab7d608328b2184dc28b5916a7)